### PR TITLE
Improve handling of gradients in addHeatmap

### DIFF
--- a/R/heatmap.R
+++ b/R/heatmap.R
@@ -62,12 +62,14 @@ addHeatmap = function(
                         heatmapDependency())
 
   #convert gradient to expected format from leaflet
-  if (!is.null(gradient) && !is.function(gradient)) {
-      gradient <- colorNumeric( gradient, 0:1 )
+  if (!is.null(gradient)) {
+    if (!is.function(gradient)) {
+      gradient <- colorNumeric( gradient, 0:1, alpha = TRUE )
+     }
       gradient <- as.list(gradient(0:20 / 20))
       names(gradient) <- as.character(0:20 / 20)
-  }
-
+   }
+    
   pts = leaflet::derivePoints(
     data, lng, lat, missing(lng), missing(lat), "addHeatmap")
 


### PR DESCRIPTION
This minor change proposes two improvements:
1) Allows user to specify a gradient of semi-transparent colors which will be incorporated in `colorNumeric` (by adding `alpha = TRUE` argument).
2) Fixes bug which prevented users from specifying a `colorNumeric` function as the `gradient` argument.